### PR TITLE
Small bug fix

### DIFF
--- a/lib/oauth2/provider/models/client.rb
+++ b/lib/oauth2/provider/models/client.rb
@@ -25,7 +25,7 @@ module OAuth2::Provider::Models::Client
 
   def allow_redirection?(uri)
     uri_host = Addressable::URI.parse(uri).host
-    if oauth_redirect_uri
+    unless oauth_redirect_uri.nil? or oauth_redirect_uri.empty?
       Addressable::URI.parse(oauth_redirect_uri).host == uri_host
     else
       !uri_host.nil? && true

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -86,6 +86,20 @@ describe OAuth2::Provider.client_class do
         subject.allow_redirection?("a-load-of-rubbish").should be_false
       end
     end
+    
+    describe "on a client with an empty oauth_redirect_uri" do
+      subject do
+        OAuth2::Provider.client_class.new :name => 'client', :oauth_redirect_uri => ""
+      end
+
+      it "always returns true" do
+        subject.allow_redirection?("http://anything.example.com/any/path").should be_true
+      end
+
+      it "returns false if the provided uri isn't a valid uri" do
+        subject.allow_redirection?("a-load-of-rubbish").should be_false
+      end
+    end
 
     describe "on a client without an oauth_redirect_uri" do
       subject do


### PR DESCRIPTION
Assuming a user edited the value of oauth_redirect_uri and changed his mind, oauth_redirect_uri would be empty as opposed to nil and hence the method would return false.
