### PR TITLE
Fix for ActiveRecord 3.1

### DIFF
--- a/lib/oauth2/provider/models/authorization_code.rb
+++ b/lib/oauth2/provider/models/authorization_code.rb
@@ -9,7 +9,7 @@ module OAuth2::Provider::Models::AuthorizationCode
     validates_presence_of :authorization, :code, :expires_at, :redirect_uri
   end
 
-  def initialize(attributes = {})
+  def initialize(*args)
     super
     self.code ||= self.class.unique_random_token(:code)
   end


### PR DESCRIPTION
The new version of active record (3.1) that will be releasing in the coming days with rails 3.1 passes an options hash as well as an attributes hash from ActiveRecord#create!. When this happens AuthorizationCode#initialize failes on an ArgumentError. It seems to be fine to just change initialize to take arbitrary arguments since the arguments are not used anyway. All tests are green (you need to bump activerecord version to make it fail with original code though).
