### PR TITLE
Middleware should pass requests to /\/oauth\/access_token/ to #handle_access_token_request.

### DIFF
--- a/lib/oauth2/provider.rb
+++ b/lib/oauth2/provider.rb
@@ -25,6 +25,8 @@ module OAuth2
 
     mattr_accessor :resource_owner_class_name
     self.resource_owner_class_name = 'ResourceOwner'
+    mattr_accessor :access_token_path
+    self.access_token_path = '/oauth/access_token'
 
     def self.configure
       yield self

--- a/lib/oauth2/provider/rack/middleware.rb
+++ b/lib/oauth2/provider/rack/middleware.rb
@@ -8,7 +8,7 @@ module OAuth2::Provider::Rack
       request = env['oauth2'] = ResourceRequest.new(env)
 
       response = catch :oauth2 do
-        if request.path =~ /\/oauth\/access_token/
+        if request.path == OAuth2::Provider.access_token_path
           handle_access_token_request(env)
         else
           @app.call(env)

--- a/spec/requests/middleware_spec.rb
+++ b/spec/requests/middleware_spec.rb
@@ -16,14 +16,26 @@ describe OAuth2::Provider::Rack::Middleware do
       end
     end
 
-    describe "requests to %r{/oauth/access_token}" do
-      it "passes requests to /oauth/access_token to #handle_access_token_request" do
-        subject.expects(:handle_access_token_request).returns(
-          [418, {'Content-Type' => 'text/plain'}, 'Short and stout']
-        )
-        get "/oauth/access_token"
-        response.status.should eql(418)
-        response.body.should eql('Short and stout')
+    it "passes requests to /oauth/access_token to #handle_access_token_request" do
+      subject.expects(:handle_access_token_request).returns(
+        [418, {'Content-Type' => 'text/plain'}, 'Short and stout']
+      )
+      get "/oauth/access_token"
+      response.status.should eql(418)
+      response.body.should eql('Short and stout')
+    end
+
+    it "passes other requests to the main app" do
+      get "/any/other/path"
+      response.status.should eql(200)
+      response.body.should eql('Apptastic')
+    end
+
+    describe "with access_token_path configured to /api/oauth/access_token" do
+      before(:each) do
+        OAuth2::Provider.configure do |config|
+          config.access_token_path = '/api/oauth/access_token'
+        end
       end
 
       it "passes requests to /api/oauth/access_token to #handle_access_token_request" do
@@ -34,12 +46,6 @@ describe OAuth2::Provider::Rack::Middleware do
         response.status.should eql(418)
         response.body.should eql('Short and stout')
       end
-    end
-
-    it "passes other requests to the main app" do
-      get "/any/other/path"
-      response.status.should eql(200)
-      response.body.should eql('Apptastic')
     end
   end
 


### PR DESCRIPTION
For example "/api/oauth/access_token" should still pass to #handle_access_token_request.
