### PR TITLE
Add 'name' as a field to match ActiveRecord schema.

### DIFF
--- a/lib/oauth2/provider/models/mongoid/client.rb
+++ b/lib/oauth2/provider/models/mongoid/client.rb
@@ -6,6 +6,7 @@ class OAuth2::Provider::Models::Mongoid::Client
       include ::Mongoid::Document
       include OAuth2::Provider::Models::Client
 
+      field :name
       field :oauth_redirect_uri
       field :oauth_secret
       field :oauth_identifier


### PR DESCRIPTION
It seems that OAuth client objects really want a 'name' field (as the AR schema implies), but Mongoid doesn't know that.
