### PR TITLE
Add client_credentials grant type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Details
 --
 
 * Implements [draft 11](http://tools.ietf.org/html/draft-ietf-oauth-v2-11) of the oauth2 spec
-* Handles the authorization_code and password grant types
+* Handles the authorization_code, password, and client_credential grant types
 * Supports ActiveRecord and Mongoid
 
 Usage Instructions

--- a/lib/oauth2/provider/models/access_token.rb
+++ b/lib/oauth2/provider/models/access_token.rb
@@ -11,10 +11,8 @@ module OAuth2::Provider::Models::AccessToken
     delegate :scope, :has_scope?, :client, :resource_owner, :to => :authorization
   end
 
-  def initialize(*args, &block)
-    super
-    self.access_token ||= self.class.unique_random_token(:access_token)
-    self.refresh_token ||= self.class.unique_random_token(:refresh_token)
+  def initialize(attributes = {}, options = {}, &block)
+    super attributes.reverse_merge(:access_token => self.class.unique_random_token(:access_token), :refresh_token => self.class.unique_random_token(:refresh_token)), options
   end
 
   def as_json(options = {})

--- a/lib/oauth2/provider/rack/access_token_handler.rb
+++ b/lib/oauth2/provider/rack/access_token_handler.rb
@@ -52,6 +52,13 @@ module OAuth2::Provider::Rack
       end
     end
 
+    def handle_client_credentials_grant_type
+      token_response OAuth2::Provider.access_token_class.create!(
+        :authorization => OAuth2::Provider.authorization_class.create!(:resource_owner => oauth_client, :client => oauth_client),
+        :refresh_token => nil
+      )
+    end
+
     def with_required_params(*names, &block)
       missing_params = names - request.params.keys
       if missing_params.empty?

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -34,6 +34,7 @@ describe OAuth2::Provider.client_class do
     it "allows any grant type (custom subclasses can override this)" do
       subject.allow_grant_type?('password').should be_true
       subject.allow_grant_type?('authorization_code').should be_true
+      subject.allow_grant_type?('client_credentials').should be_true
     end
   end
 

--- a/spec/requests/access_tokens_controller_spec.rb
+++ b/spec/requests/access_tokens_controller_spec.rb
@@ -310,6 +310,40 @@ describe "POSTs to /oauth/access_token" do
     end
   end
 
+  describe "A request using the client_credentials grant type" do
+    before :each do
+      @valid_params = {
+        :grant_type => 'client_credentials',
+        :client_id => @client.to_param,
+        :client_secret => @client.oauth_secret
+      }
+    end
+
+    describe "with valid client_id and client_secret" do
+      before :each do
+        post "/oauth/access_token", @valid_params
+      end
+
+      it "responds with access token, and expiry time in JSON" do
+        token = OAuth2::Provider.access_token_class.find_by_access_token(json_from_response["access_token"])
+        token.should_not be_nil
+        json_from_response["expires_in"].should == token.expires_in
+      end
+
+      it "sets cache-control header to no-store, as response is sensitive" do
+        response.headers["Cache-Control"].should =~ /no-store/
+      end
+
+      it "doesn't include a refresh_token in the JSON response" do
+        json_from_response.keys.include?("refresh_token").should be_false
+      end
+
+      it "doesn't include a state in the JSON response" do
+        json_from_response.keys.include?("state").should be_false
+      end
+    end
+  end
+
   describe "When using a custom client class" do
     before :each do
       @original_client_class_name = OAuth2::Provider.client_class_name


### PR DESCRIPTION
Allows a client to use client_id and client_secret to obtain a non refreshable access token:
http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.4
