### PR TITLE
General auth header creds

### DIFF
--- a/lib/oauth2/provider/rack/access_token_handler.rb
+++ b/lib/oauth2/provider/rack/access_token_handler.rb
@@ -19,12 +19,9 @@ module OAuth2::Provider::Rack
     end
 
     def handle_basic_auth_header
-      with_required_params 'grant_type' do |grant_type|
-        if grant_type == 'client_credentials' && request.env['HTTP_AUTHORIZATION'] =~ /^Basic/
-          @env['oauth2'].params['client_id'], @env['oauth2'].params['client_secret'] = HTTPAuth::Basic.unpack_authorization(request.env['HTTP_AUTHORIZATION'])
-          next
-        end
-      end
+      return unless request.env['HTTP_AUTHORIZATION'] =~ /^Basic/
+      @env['oauth2'].params['client_id'], @env['oauth2'].params['client_secret'] = HTTPAuth::Basic.unpack_authorization(request.env['HTTP_AUTHORIZATION'])
+      nil
     end
 
     def handle_grant_type

--- a/lib/oauth2/provider/rack/access_token_handler.rb
+++ b/lib/oauth2/provider/rack/access_token_handler.rb
@@ -19,8 +19,9 @@ module OAuth2::Provider::Rack
     end
 
     def handle_basic_auth_header
-      return unless request.env['HTTP_AUTHORIZATION'] =~ /^Basic/
-      @env['oauth2'].params['client_id'], @env['oauth2'].params['client_secret'] = HTTPAuth::Basic.unpack_authorization(request.env['HTTP_AUTHORIZATION'])
+      if request.env['HTTP_AUTHORIZATION'] =~ /^Basic/
+        @env['oauth2'].params['client_id'], @env['oauth2'].params['client_secret'] = HTTPAuth::Basic.unpack_authorization(request.env['HTTP_AUTHORIZATION'])
+      end
       nil
     end
 

--- a/spec/requests/access_tokens_controller_spec.rb
+++ b/spec/requests/access_tokens_controller_spec.rb
@@ -114,7 +114,7 @@ describe "POSTs to /oauth/access_token" do
   end
 
 
-  context "using supported grant type" do
+  context "Requests for the supported grant type" do
 
     shared_examples_for :token_response do
       it "sets cache-control header to no-store, as response is sensitive" do
@@ -147,7 +147,7 @@ describe "POSTs to /oauth/access_token" do
       end
     end
 
-    describe "authorization_code" do
+    describe "'authorization_code'" do
       shared_examples :authorization_code_grant do
         describe "with valid client, code and redirect_uri" do
           before :each do
@@ -227,7 +227,7 @@ describe "POSTs to /oauth/access_token" do
       end
     end
 
-    describe "password" do
+    describe "'password'" do
       before :each do
         @resource_owner = ExampleResourceOwner.create!(:username => 'name', :password => 'password')
         @valid_params = {
@@ -312,7 +312,7 @@ describe "POSTs to /oauth/access_token" do
       end
     end
 
-    describe "refresh_token" do
+    describe "'refresh_token'" do
       before :each do
         @token = create_access_token
 

--- a/spec/requests/access_tokens_controller_spec.rb
+++ b/spec/requests/access_tokens_controller_spec.rb
@@ -114,7 +114,7 @@ describe "POSTs to /oauth/access_token" do
   end
 
 
-  context "Requests for the supported grant type" do
+  context "Requests using grant_type" do
 
     shared_examples_for :token_response do
       it "sets cache-control header to no-store, as response is sensitive" do


### PR DESCRIPTION
Resolves issue #30 -- Extended support for passing client credentials in headers to all supported flows. Code change was minimal, and I've updated the tests to try and cover the additional happy-path cases. I've also integration tested against another project and had success there.

Apologies about the big delta in the specs. Perhaps I tried to extract shared_example blocks too aggressively. If you object, I'm more than happy to try to reduce the size of that diff, but I feel like the new version has some advantages.
