### PR TITLE
Client confidentiality

### DIFF
--- a/lib/oauth2/provider/models/client.rb
+++ b/lib/oauth2/provider/models/client.rb
@@ -20,7 +20,7 @@ module OAuth2::Provider::Models::Client
   end
 
   def allow_grant_type?(grant_type)
-    true
+    confidential? || grant_type != "client_credentials"
   end
 
   def allow_redirection?(uri)

--- a/lib/oauth2/provider/models/mongoid/client.rb
+++ b/lib/oauth2/provider/models/mongoid/client.rb
@@ -10,6 +10,7 @@ class OAuth2::Provider::Models::Mongoid::Client
       field :oauth_redirect_uri
       field :oauth_secret
       field :oauth_identifier
+      field :confidential, 'type' => Boolean, 'default' => false
 
       has_many(:authorizations,
         :class_name => OAuth2::Provider.authorization_class_name,

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -9,6 +9,7 @@ ActiveRecord::Schema.define(:version => 20110323171649) do
     t.string   'oauth_redirect_uri'
     t.string   'oauth_identifier', :null => false
     t.string   'oauth_secret', :null => false
+    t.boolean  'confidential', :default => false
   end
 
   create_table 'oauth_authorization_codes', :force => true do |t|


### PR DESCRIPTION
Added support for a the new oauth2-protocol concept of client "confidentiality" -- in a nutshell:
- "Confidential" clients can keep their oauth_secret secret, and therefore CAN be trusted to use the client_credentials flow
-  "Public" clients can't necessarily keep their oauth_secret secret, and therefore CAN'T be trusted to use the client_credentials flow (but can still present client credentials when using other flows)

Note that this introduces a new column in the schema. Not an issue for mongoid, but SQL-schemas must be updated. I haven't attempted to address that process in this PR, but would be willing to dig into more later.
